### PR TITLE
fix(docs): link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The CO₂ Shield Generator lets you calculate the environmental impact of a webp
 
 You don't need to download or initialise anything to use this tool. Visit the live version here:
 
-👉 [**CO₂ Shield Generator**](https://https://overbrowsing.com/projects/co2-shield/)
+👉 [**CO₂ Shield Generator**](https://overbrowsing.com/projects/co2-shield)
 
 ## Features
 


### PR DESCRIPTION
Currently the live tool's url specified in README has:
- extra `https`
- a trailing `/` that when add to the end of url, returns `404`

By removing those two typos, the link in README is now working as expected.